### PR TITLE
feat: Use anthropic-claude-code E2B template with fallback installation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1351,14 +1351,18 @@ program
   .requiredOption('--repo <path>', 'Repository path')
   .option('--prompt <text>', 'Prompt text to execute')
   .option('--prompt-file <path>', 'Path to prompt file (e.g., PLAN.md, .apm/Implementation_Plan.md)')
-  .option('--template <image>', 'E2B sandbox template (default: anthropic-claude-code)', 'anthropic-claude-code')
+  .option('--template <image>', 'E2B sandbox template (default: anthropic-claude-code or E2B_TEMPLATE env var)')
   .option('--dry-run', 'Test upload without execution (useful for verifying workspace)')
   .option('--no-commit', 'Skip auto-commit of results to worktree')
   .option('--json', 'Output as JSON')
   .action(async (options) => {
     const coordinator = new Coordinator();
+    // Precedence: CLI option > E2B_TEMPLATE env var > default 'anthropic-claude-code'
+    const sandboxImage = options.template ||
+                         (process.env.E2B_TEMPLATE?.trim() || '') ||
+                         'anthropic-claude-code';
     const sandboxManager = new SandboxManager(logger, {
-      sandboxImage: options.template || 'anthropic-claude-code'
+      sandboxImage
     });
     let sandboxId: string | null = null;
 

--- a/src/e2b/sandbox-manager.ts
+++ b/src/e2b/sandbox-manager.ts
@@ -18,10 +18,11 @@ import {
 } from '../types.js';
 
 // Default configuration
+const envTemplate = process.env.E2B_TEMPLATE?.trim();
 const DEFAULT_CONFIG: Required<E2BSessionConfig> = {
   claudeVersion: 'latest',
   e2bSdkVersion: '1.13.2',
-  sandboxImage: process.env.E2B_TEMPLATE || 'anthropic-claude-code', // E2B template with pre-installed Claude Code
+  sandboxImage: (envTemplate && envTemplate.length > 0) ? envTemplate : 'anthropic-claude-code', // E2B template with pre-installed Claude Code
   timeoutMinutes: 60,
   warningThresholds: [30, 50]
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -474,7 +474,7 @@ export interface SuggestionFilters {
 export interface E2BSessionConfig {
   claudeVersion?: string; // e.g., "1.0.0" or "latest"
   e2bSdkVersion: string; // Pin E2B SDK version
-  sandboxImage: string; // Recommended: "anthropic-claude-code" (pre-installed Claude Code). Fallback: "base" requires manual Node.js + npm install @anthropic-ai/claude-code
+  sandboxImage: string; // Recommended: "anthropic-claude-code" (pre-installed Claude Code). Fallback: "base" or custom images auto-install via apt-get (Debian/Ubuntu required) then npm install -g @anthropic-ai/claude-code
   timeoutMinutes?: number; // Default: 60
   warningThresholds?: number[]; // Default: [30, 50] minutes
 }

--- a/tests/e2b/sandbox-manager.test.ts
+++ b/tests/e2b/sandbox-manager.test.ts
@@ -42,6 +42,7 @@ describe('SandboxManager', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    delete process.env.E2B_TEMPLATE;
 
     // Create mock logger
     mockLogger = createMockLogger();
@@ -69,6 +70,7 @@ describe('SandboxManager', () => {
   afterEach(() => {
     vi.clearAllTimers();
     delete process.env.E2B_API_KEY;
+    delete process.env.E2B_TEMPLATE;
   });
 
   describe('constructor', () => {


### PR DESCRIPTION
## Problem

E2B sandbox executions were failing with "command not found" (exit 127) because the default `base` image lacks Node.js and Claude Code CLI. This caused `claude update` and `echo "prompt" | claude -p` commands to fail, breaking autonomous sandbox execution.

## Solution

Switch default E2B sandbox template to `anthropic-claude-code` which comes with Claude Code pre-installed, and add fallback installation for custom/base images.

## Changes

### Core Implementation

1. **Default Template Switch** (`src/e2b/sandbox-manager.ts`)
   - Changed `DEFAULT_CONFIG.sandboxImage` from `'base'` to `'anthropic-claude-code'`
   - Added `E2B_TEMPLATE` environment variable override
   - Pre-installed Claude Code eliminates installation overhead

2. **Fallback Installation** (`src/e2b/claude-runner.ts`)
   - New `ensureClaudeCode()` function checks for Claude CLI with `which claude`
   - Falls back to `npm install -g @anthropic-ai/claude-code` if missing
   - Installs Node.js dependencies automatically
   - 3-minute timeout for installation on base/custom images

3. **Workflow Integration** (`src/e2b/claude-runner.ts`)
   - Added Step 1.5 to `executeClaudeInSandbox()`: verify Claude CLI
   - Runs after sandbox health check, before Claude update
   - Returns clear error if installation fails

4. **Enhanced Error Handling** (`src/e2b/claude-runner.ts`)
   - Detects exit code 127 and "not found" errors
   - Provides helpful diagnostic: "Use anthropic-claude-code template or check installation"
   - Added to both `runClaudeUpdate()` and `runClaudeWithPrompt()` catch blocks

5. **CLI Template Option** (`src/cli.ts`)
   - Added `--template <image>` option to `sandbox-run` command
   - Default: `'anthropic-claude-code'`
   - Updated command description to document template usage
   - Passes template config to SandboxManager

6. **Documentation** (`src/types.ts`)
   - Updated `E2BSessionConfig.sandboxImage` JSDoc comment
   - Recommends `anthropic-claude-code` for pre-installed Claude Code
   - Documents fallback requirement for `base` template

### Testing

- **Updated Tests** (`tests/e2b/sandbox-manager.test.ts`)
  - Fixed 3 tests expecting `'base'` to expect `'anthropic-claude-code'`
  - All 82 sandbox-manager tests passing ✓

- **Verified CLI**
  ```bash
  parallel-cc sandbox-run --help
  # Shows: --template <image> (default: anthropic-claude-code)
  ```

## Architecture Flow

```
┌─────────────────────────────────────────────────────────┐
│ 1. Create Sandbox (anthropic-claude-code template)     │
│    - Claude Code pre-installed                         │
│    - No installation needed                            │
└─────────────────────────────────────────────────────────┘
                          ↓
┌─────────────────────────────────────────────────────────┐
│ 1.5. Ensure Claude Code (NEW)                          │
│    - Check: which claude                               │
│    - If missing: install Node.js + npm + Claude        │
│    - Timeout: 3 minutes                                │
└─────────────────────────────────────────────────────────┘
                          ↓
┌─────────────────────────────────────────────────────────┐
│ 2. Run Claude Update                                    │
│    - claude update                                      │
│    - Error detection: exit 127 → helpful message       │
└─────────────────────────────────────────────────────────┘
                          ↓
┌─────────────────────────────────────────────────────────┐
│ 3. Execute Prompt                                       │
│    - echo "prompt" | claude -p                         │
│    - Stream output in real-time                        │
└─────────────────────────────────────────────────────────┘
```

## Configuration

| Setting | Old | New | Override |
|---------|-----|-----|----------|
| `sandboxImage` | `'base'` | `'anthropic-claude-code'` | `E2B_TEMPLATE` env var |
| Claude CLI | Manual install | Pre-installed | Fallback for custom images |
| Startup Time | ~3 min (install) | ~10 sec (ready) | N/A |

## Usage

### Default (Recommended)
```bash
parallel-cc sandbox-run --repo . --prompt "Implement feature X"
# Uses anthropic-claude-code template automatically
```

### Custom Template
```bash
parallel-cc sandbox-run --repo . --prompt "Test" --template base
# Falls back to npm install if Claude missing
```

### Environment Override
```bash
E2B_TEMPLATE=custom-image parallel-cc sandbox-run --repo . --prompt "Test"
# Uses custom template with fallback installation
```

## Impact

✅ **Fixes**: E2B sandbox "command not found" errors  
✅ **Reduces**: Startup time from ~3 minutes to ~10 seconds  
✅ **Improves**: Reliability with pre-installed Claude Code  
✅ **Maintains**: Flexibility with custom template support  
✅ **Enhances**: Error messages with actionable diagnostics  

## Testing Checklist

- [x] All 82 sandbox-manager tests passing
- [x] TypeScript builds without errors
- [x] CLI help shows new --template option
- [x] Default template documented in code comments
- [ ] E2E test with E2B_API_KEY (requires live E2B account)
- [ ] Verify anthropic-claude-code template exists in E2B catalog
- [ ] Test fallback installation with base template

## Rollout Plan

1. Merge to main
2. Update README.md with template information
3. Update SANDBOX_INTEGRATION_PLAN.md documentation
4. Monitor first E2B executions for template availability
5. Consider adding E2E integration tests

## Breaking Changes

None - the change is backwards compatible:
- Existing code continues to work
- Custom templates supported via --template flag
- Environment variable override available
- Fallback installation handles base template

---

**Related Issue**: Fixes E2B sandbox execution failures  
**Documentation**: Inline JSDoc comments updated  
**Testing**: All existing tests passing, updated to match new default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to specify the sandbox template image (defaults to anthropic-claude-code).
  * Sandbox image can now be configured via an environment variable with a clear precedence order.

* **Bug Fixes**
  * Improved detection and diagnostics for missing Claude Code CLI, with guidance when installation fails.

* **Tests**
  * Updated tests to reflect the new default template and to isolate the template environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->