### PR TITLE
feat: Add early E2B API key validation to fail fast

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1442,6 +1442,25 @@ Examples:
         }
       }
 
+      // Validate E2B API key early (fail fast before resource-intensive operations)
+      try {
+        SandboxManager.validateApiKey();
+      } catch (error) {
+        if (options.json) {
+          console.log(JSON.stringify({
+            success: false,
+            error: error instanceof Error ? error.message : 'E2B API key validation failed',
+            hint: 'Set E2B_API_KEY environment variable. Get your key from https://e2b.dev/dashboard'
+          }));
+        } else {
+          console.error(chalk.red(`✗ ${error instanceof Error ? error.message : 'E2B API key validation failed'}`));
+          console.error(chalk.dim('  Get your E2B API key from: https://e2b.dev/dashboard'));
+          console.error(chalk.yellow('  Set it with: export E2B_API_KEY="your-key-here"'));
+          console.error(chalk.dim('  Add to your shell profile (.bashrc, .zshrc) for persistence'));
+        }
+        process.exit(1);
+      }
+
       // Read prompt
       let prompt: string;
       if (options.promptFile) {
@@ -1898,6 +1917,23 @@ program
     const sandboxManager = new SandboxManager(logger);
 
     try {
+      // Validate E2B API key early
+      try {
+        SandboxManager.validateApiKey();
+      } catch (error) {
+        if (options.json) {
+          console.log(JSON.stringify({
+            success: false,
+            error: error instanceof Error ? error.message : 'E2B API key validation failed',
+            hint: 'Set E2B_API_KEY environment variable. Get your key from https://e2b.dev/dashboard'
+          }));
+        } else {
+          console.error(chalk.red(`✗ ${error instanceof Error ? error.message : 'E2B API key validation failed'}`));
+          console.error(chalk.dim('  Get your E2B API key from: https://e2b.dev/dashboard'));
+        }
+        process.exit(1);
+      }
+
       const db = coordinator['db'];
       const sessionId = options.sessionId;
 

--- a/src/e2b/sandbox-manager.ts
+++ b/src/e2b/sandbox-manager.ts
@@ -104,6 +104,21 @@ export class SandboxManager {
   }
 
   /**
+   * Validate E2B API key is present
+   *
+   * @param apiKey - Optional API key to validate
+   * @throws Error if API key is not found
+   */
+  static validateApiKey(apiKey?: string): void {
+    const e2bApiKey = apiKey || process.env.E2B_API_KEY;
+    if (!e2bApiKey) {
+      throw new Error(
+        'E2B API key not found. Set E2B_API_KEY environment variable or pass apiKey parameter.'
+      );
+    }
+  }
+
+  /**
    * Create a new E2B sandbox
    *
    * @param sessionId - Unique session identifier
@@ -118,12 +133,8 @@ export class SandboxManager {
       this.logger.info(`Creating E2B sandbox for session ${sessionId}`);
 
       // Validate API key (required for E2B)
+      SandboxManager.validateApiKey(apiKey);
       const e2bApiKey = apiKey || process.env.E2B_API_KEY;
-      if (!e2bApiKey) {
-        throw new Error(
-          'E2B API key not found. Set E2B_API_KEY environment variable or pass apiKey parameter.'
-        );
-      }
 
       // Create sandbox using E2B SDK
       // E2B SDK signature: Sandbox.create(template, opts)

--- a/tests/e2b/sandbox-manager.test.ts
+++ b/tests/e2b/sandbox-manager.test.ts
@@ -106,6 +106,34 @@ describe('SandboxManager', () => {
     });
   });
 
+  describe('validateApiKey (static)', () => {
+    it('should not throw when API key is in environment', () => {
+      process.env.E2B_API_KEY = 'test-key';
+      expect(() => SandboxManager.validateApiKey()).not.toThrow();
+    });
+
+    it('should not throw when API key is passed as parameter', () => {
+      delete process.env.E2B_API_KEY;
+      expect(() => SandboxManager.validateApiKey('custom-key')).not.toThrow();
+    });
+
+    it('should throw when API key is missing from environment', () => {
+      delete process.env.E2B_API_KEY;
+      expect(() => SandboxManager.validateApiKey()).toThrow(/E2B API key not found/);
+    });
+
+    it('should prefer parameter over environment variable', () => {
+      process.env.E2B_API_KEY = 'env-key';
+      // Should not throw even if parameter is provided
+      expect(() => SandboxManager.validateApiKey('param-key')).not.toThrow();
+    });
+
+    it('should throw with helpful error message', () => {
+      delete process.env.E2B_API_KEY;
+      expect(() => SandboxManager.validateApiKey()).toThrow(/Set E2B_API_KEY environment variable/);
+    });
+  });
+
   describe('createSandbox', () => {
     it('should create sandbox successfully with session ID', async () => {
       const result = await manager.createSandbox('session-123');


### PR DESCRIPTION
## Summary

Implements early E2B_API_KEY validation before resource-intensive operations to provide immediate feedback when the API key is missing.

**Problem:** The `sandbox-run` command was failing after 26+ seconds (after worktree setup, credential scanning, and tarball creation) when E2B_API_KEY was missing.

**Solution:** Added immediate validation right after authentication checks and before any file operations.

## Changes

### Core Implementation
- **Added `SandboxManager.validateApiKey()` static method** (src/e2b/sandbox-manager.ts)
  - Checks for E2B_API_KEY in environment or parameter
  - Throws descriptive error with actionable guidance
  - Reusable across all E2B commands

- **Early validation in `sandbox-run`** (src/cli.ts:1445-1462)
  - Validates immediately after auth method checks
  - Before Step 1 (worktree setup)
  - Before Step 2 (credential scanning)
  - Before Step 3 (tarball creation ~26s)

- **Early validation in `sandbox-download`** (src/cli.ts:1920-1935)
  - Consistency across E2B commands

- **Updated `createSandbox()`** (src/e2b/sandbox-manager.ts:136)
  - Uses static validation helper

### Testing
- **5 new unit tests** for static validation method (tests/e2b/sandbox-manager.test.ts:109-135)
  - Environment variable validation
  - Parameter validation
  - Missing key error handling
  - Parameter precedence
  - Error message quality

### User Experience Improvements
- **Clear error messages** with links to E2B dashboard
- **Actionable instructions** for setting environment variable
- **Shell profile suggestions** for persistence
- **Proper JSON output** for automation/scripting

## Test Results

✅ **All 87 sandbox-manager tests pass**
✅ **All 92 core tests pass** (db + coordinator)
✅ **Manual verification complete**

### Manual Testing
```bash
# Missing E2B_API_KEY - fails immediately ✅
$ node dist/cli.js sandbox-run --repo . --prompt "test"
✗ E2B API key not found. Set E2B_API_KEY environment variable...
  Get your E2B API key from: https://e2b.dev/dashboard
  Set it with: export E2B_API_KEY="your-key-here"
  Add to your shell profile (.bashrc, .zshrc) for persistence

# JSON mode - proper error response ✅
$ node dist/cli.js sandbox-run --repo . --prompt "test" --json
{"success":false,"error":"E2B API key not found...","hint":"Set E2B_API_KEY..."}

# Valid key - proceeds to Steps 1-3 ✅
$ export E2B_API_KEY="test-key"
$ node dist/cli.js sandbox-run --repo . --prompt "test"
🚀 Starting E2B Sandbox Execution
Step 1/6: Setting up isolated worktree...
Step 2/6: Scanning for credentials...
Step 3/6: Creating workspace tarball...
```

## Impact

### Before
- ❌ Failed after ~26 seconds
- ❌ After completing worktree setup
- ❌ After credential scanning
- ❌ After tarball creation

### After
- ✅ Fails **immediately** (<1 second)
- ✅ Before any resource-intensive operations
- ✅ Clear, actionable error messages
- ✅ Proper JSON output support

## Review Checklist

- [x] Tests added and passing
- [x] Manual testing completed
- [x] Error messages are clear and actionable
- [x] JSON output mode supported
- [x] Follows conventional commit format
- [x] No secrets in code
- [x] Documentation updated (inline comments)

## Related

Addresses the issue where E2B sandbox commands fail late in the execution flow when API keys are missing, causing frustration and wasted time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Early API key validation integrated into CLI commands with immediate failure detection
  * Improved error messaging with helpful guidance information
  * Added JSON-formatted error output support for API validation failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->